### PR TITLE
Initialize `dot` after install. This command is needed on Apple M2 machines.

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # paths to emmocheck and ontodoc (from https://github.com/emmo-repo/EMMOntoPy)
 CHECK=emmocheck
 
@@ -13,6 +14,10 @@ ls -ls magnetic_material_mammos.ttl
 
 echo "checking ontology ..."
 $CHECK magnetic_material_mammos.ttl
+
+
+# on ARM Mac, this seems required once to build documentation
+doc -c
 
 echo "building documentation ..."
 cd doc

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,8 @@ version = "0.1.0"
 [tasks]
 build = "python src/build_onto.py"
 check = "emmocheck magnetic_material_mammos.ttl"
-docs = {cmd = "python mammosdoc --template=mammos.md --local --format=html ../magnetic_material_mammos.ttl magnetic_material_mammos.html", cwd = "doc"}
+init_dot = "dot -c"  # needed on Mac M2 before graphviz can be used
+docs = {cmd = "python mammosdoc --template=mammos.md --local --format=html ../magnetic_material_mammos.ttl magnetic_material_mammos.html", cwd = "doc", depends_on = ['init_dot']}
 clean = "rm -f demo.sqlite3 magnetic_material_mammos.ttl doc/magnetic_material_mammos.html"
 
 # convenience target: run all steps subsequently


### PR DESCRIPTION
It is not clear why. Perhaps an error in the ARM64 package, and thus doesn't show else where.

This change fixes the problem for Hans and Santa on a M2 machine. (Apple Intel is working fine without it, and so is Linux as we know from the CI.)