### PR TITLE
fix mistake in the definition of MagnetocrystallineAnisotropyConstantK2c in ontology

### DIFF
--- a/src/build_onto.py
+++ b/src/build_onto.py
@@ -426,8 +426,8 @@ with onto:
             anisotropy energy density and a1,a2,a3 are the direction \
             cosines of the magnetization"
         )
-        prefLabel = en("MagnetocrystallineAnisotropyConstantK1c")
-        altLabel = en("K1")
+        prefLabel = en("MagnetocrystallineAnisotropyConstantK2c")
+        altLabel = en("K2")
         wikipediaReference = pl(
             "https://en.wikipedia.org/wiki/Magnetocrystalline_anisotropy"
         )


### PR DESCRIPTION
Should fix https://github.com/MaMMoS-project/MagneticMaterialsOntology/issues/7