### PR TITLE
refactor some labels

### DIFF
--- a/src/build_onto.py
+++ b/src/build_onto.py
@@ -881,7 +881,7 @@ with onto:
         altLabel = [
             en("KneeFieldInternal"),
             en("MaximumWorkingField"),
-            en("Hk"),
+            pl("Hk"),
         ]
 
     class KneeFieldExternal(emmo.MagneticFieldStrength):


### PR DESCRIPTION
Closes https://github.com/MaMMoS-project/MagneticMaterialsOntology/issues/30

Proposed approach:
- non-english words are stored as `pl` (plain)
- altLabels that before were squashed together now are appended (for example: `"sigma, SpecificMagneticMoment"` -> `"sigma", "SpecificMagneticMoment"`).
- Removed all spaces and used CamelCase for those labels that were missing it (for example: `"crystal orientation"` -> `"CrystalOrientation"`.
- Adopted @stibus 's suggestion: for example `"XRDTwoThetaAngles"` -> `"XrdTwoThetaAngles"`. But for the members with XRD I still keep the original (es: `"XRDTwoThetaAngles"`) as an `altLabel`.